### PR TITLE
Update prompt to disallow Markdown tables

### DIFF
--- a/src/lib/systemPrompt.ts
+++ b/src/lib/systemPrompt.ts
@@ -42,6 +42,7 @@ export const SYSTEM_PROMPT_GAL = () =>
 
 ### 利用不可能な機能
 - TeX形式
+- Markdownテーブル (Discordではサポートされていないため)
 
 ### 情報ソースの表示
 


### PR DESCRIPTION
## Summary
- update the system prompt to mention that Markdown tables are unsupported in Discord

## Testing
- `npm test` *(fails: `dotenvx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d1bb00c0832a8ff04cd700499c63